### PR TITLE
update blosc, HDF5 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,11 +24,11 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Blosc = "0.5.1"
+Blosc = "0.5.1, 0.6, 0.7"
 DSP = "0.5, 0.6"
 FFTW = "1.1"
 Glob = "1.2.0"
-HDF5 = "=0.12.3"
+HDF5 = "0.12.3,0.13"
 HTTP = "0.8.12"
 LightXML = "0.8.1"
 julia = "1"


### PR DESCRIPTION
This PR updates `Blosc` and `HDF5` compat to the latest versions. This is useful for including SeisIO in packages that only support the latest versions of `Blosc` and `HDF5`. This should be a solution for #49 and #58. 