### PR TITLE
Update paths for tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,24 @@ Designed for speed, efficiency, and ease of use. Includes web clients, readers f
 ## Getting Started | [Formats](docs/FORMATS.md) | [Web Clients](docs/WEB.md)
 Start the tutorials in your browser from the Julia prompt with
 
-`cd(dirname(pathof(SeisIO))); include("../tutorial/install.jl")`
+```julia
+using SeisIO
+cd(dirname(pathof(SeisIO)))
+include("../tutorial/install.jl")
+```
 
 To run SeisIO package tests and download sample data, execute
 
-`using Pkg, SeisIO; Pkg.test("SeisIO")`
+```julia
+using Pkg, SeisIO; Pkg.test("SeisIO")
+```
 
 Sample data downloaded for the tests can be found thereafter at
 
-`cd(dirname(pathof(SeisIO))); sfdir = realpath("../test/SampleFiles/")`
+```julia
+cd(dirname(pathof(SeisIO))) 
+sfdir = realpath("../test/SampleFiles/")
+```
 
 ## Publications | [Changelog](docs/CHANGELOG.md) | [Issues](docs/ISSUES.md)
 Jones, J.P.,  Okubo, K., Clements. T., \& Denolle, M. (2020). SeisIO: a fast, efficient geophysical data architecture for the Julia language. *Seismological Research Letters* doi: https://doi.org/10.1785/0220190295

--- a/tutorial/install.jl
+++ b/tutorial/install.jl
@@ -1,7 +1,7 @@
 using IJulia
 import SeisIO: get_svn
-path = Base.source_dir()
-include(path * "../test/TestHelpers/0_check_deps.jl")
+path = joinpath(Base.source_dir(),"../test/TestHelpers/0_check_deps.jl")
+include(path)
 pkg_check(["DSP", "SeisIO", "IJulia"])
 get_svn("https://github.com/jpjones76/SeisIO-TestData/trunk/Tutorial", "DATA")
-jupyterlab(dir=pwd())
+jupyterlab(dir=joinpath(dirname(dirname(pathof(SeisIO))),"tutorial"))


### PR DESCRIPTION
This PR is a fix for #76. I made a change so that jupyter opens in the tutorial directory and updated the README page to use Julia syntax highlighting. Pushing this to master, as it does not change any source code. 